### PR TITLE
Typesafe property

### DIFF
--- a/core/src/main/kotlin/de/mineking/database/Conditions.kt
+++ b/core/src/main/kotlin/de/mineking/database/Conditions.kt
@@ -2,6 +2,7 @@ package de.mineking.database
 
 import de.mineking.database.Where.Companion.combine
 import org.jdbi.v3.core.argument.Argument
+import kotlin.reflect.KProperty
 
 fun interface Order {
     fun get(): String
@@ -11,7 +12,10 @@ fun interface Order {
 }
 
 fun ascendingBy(name: String) = Order { "\"$name\" asc" }
+fun ascendingBy(property: KProperty<*>) = ascendingBy(property.name)
+
 fun descendingBy(name: String) = Order { "\"$name\" desc" }
+fun descendingBy(property: KProperty<*>) = descendingBy(property.name)
 
 interface Where {
     companion object {
@@ -72,26 +76,26 @@ fun <T: Any> identifyObject(table: TableStructure<T>, obj: T): Where {
     return allOf(keys.map { unsafeNode(it.name) isEqualTo value(it.get(obj), it.type) })
 }
 
-fun Where(node: Node): Where = object : Where {
+fun Where(node: Node<*>): Where = object : Where {
     override fun get(table: TableStructure<*>): String = node.format(table)
     override fun values(table: TableStructure<*>): Map<String, Argument> = node.values(table, node.columnContext(table)?.column)
 }
 
-infix fun Node.isEqualTo(other: Node) = Where(this + " = " + other)
-infix fun Node.isNotEqualTo(other: Node) = Where(this + " != " + other)
+infix fun Node<*>.isEqualTo(other: Node<*>) = Where(this + " = " + other)
+infix fun Node<*>.isNotEqualTo(other: Node<*>) = Where(this + " != " + other)
 
-infix fun Node.isLike(other: String) = Where(this + " like '" + other + "'")
+infix fun Node<*>.isLike(other: String) = Where(this + " like '" + other + "'")
 
-fun Node.isIn(nodes: Array<Node>) = Where(this + " in (" + nodes.join() + ")")
-fun Node.isIn(nodes: Collection<Node>) = isIn(nodes.toTypedArray())
+fun Node<*>.isIn(nodes: Array<Node<*>>) = Where(this + " in (" + nodes.join() + ")")
+fun Node<*>.isIn(nodes: Collection<Node<*>>) = isIn(nodes.toTypedArray())
 
-infix fun Node.isGreaterThan(other: Node) = Where(this + " > " + other)
-infix fun Node.isGreaterThanOrEqual(other: Node) = Where(this + " >= " + other)
+infix fun Node<*>.isGreaterThan(other: Node<*>) = Where(this + " > " + other)
+infix fun Node<*>.isGreaterThanOrEqual(other: Node<*>) = Where(this + " >= " + other)
 
-infix fun Node.isLowerThan(other: Node) = Where(this + " < " + other)
-infix fun Node.isLowerThanOrEqual(other: Node) = Where(this + " <= " + other)
+infix fun Node<*>.isLowerThan(other: Node<*>) = Where(this + " < " + other)
+infix fun Node<*>.isLowerThanOrEqual(other: Node<*>) = Where(this + " <= " + other)
 
-fun Node.isBetween(a: Node, b: Node) = Where(this + " between " + a + " and " + b)
+fun Node<*>.isBetween(a: Node<*>, b: Node<*>) = Where(this + " between " + a + " and " + b)
 
-fun Node.isNull(): Where = Where(this + " is null")
-fun Node.isNotNull(): Where = Where(this + " is not null")
+fun Node<*>.isNull(): Where = Where(this + " is null")
+fun Node<*>.isNotNull(): Where = Where(this + " is not null")

--- a/core/src/main/kotlin/de/mineking/database/DataObject.kt
+++ b/core/src/main/kotlin/de/mineking/database/DataObject.kt
@@ -1,5 +1,7 @@
 package de.mineking.database
 
+import kotlin.reflect.KProperty
+
 @Suppress("UNCHECKED_CAST")
 interface DataObject<T: Any> {
 	fun getTable(): Table<T>
@@ -9,12 +11,14 @@ interface DataObject<T: Any> {
 	fun upsert() = getTable().upsert(this as T)
 	fun delete() = getTable().delete(this as T)
 
-	fun <O: Any> selectReferring(table: Table<O>, reference: String, where: Where = Where.EMPTY): QueryResult<O> {
+	fun <O: Any> selectReferring(table: Table<O>, reference: Node<*>, where: Where = Where.EMPTY): QueryResult<O> {
 		val keys = getTable().structure.getKeys()
 		require(keys.size == 1) { "Cannot select referring objects when having multiple keys" }
 
-		return table.select(where = property(reference) isEqualTo value(keys[0].get(this as T)) and where)
+		return table.select(where = reference isEqualTo value(keys[0].get(this as T)) and where)
 	}
+
+	fun <O: Any> selectReferring(table: Table<O>, reference: KProperty<*>, where: Where = Where.EMPTY): QueryResult<O> = selectReferring(table, property(reference), where)
 
 	fun beforeWrite() {}
 	fun afterRead() {}

--- a/core/src/main/kotlin/de/mineking/database/Nodes.kt
+++ b/core/src/main/kotlin/de/mineking/database/Nodes.kt
@@ -1,12 +1,14 @@
 package de.mineking.database
 
 import org.jdbi.v3.core.argument.Argument
+import kotlin.reflect.KProperty
+import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 
-fun Array<out Node>.join(delimiter: Node = unsafeNode(", ")): Node {
+fun Array<out Node<*>>.join(delimiter: Node<*> = unsafeNode(", ")): Node<*> {
 	var result = Node.EMPTY
 
 	val iterator = iterator()
@@ -20,25 +22,46 @@ fun Array<out Node>.join(delimiter: Node = unsafeNode(", ")): Node {
 	return result
 }
 
-operator fun String.invoke(vararg params: Node) = unsafeNode(this) + "(" + params.join() + ")"
+operator fun String.invoke(vararg params: Node<*>) = unsafeNode(this) + "(" + params.join() + ")"
 
-fun length(node: Node) = "len"(node)
-fun lowerCase(node: Node) = "lower"(node)
-fun upperCase(node: Node) = "upper"(node)
+@Suppress("UNCHECKED_CAST")
+fun Node<String>.length() = "length"(this) as Node<Int>
 
-fun abs(node: Node) = "abs"(node)
+@Suppress("UNCHECKED_CAST")
+fun Node<String>.lowercase() = "lower"(this) as Node<String>
 
-operator fun Node.get(index: Node) = this + "[" + index + "]"
+@Suppress("UNCHECKED_CAST")
+fun Node<String>.uppercase() = "upper"(this) as Node<String>
+
+fun abs(node: Node<Number>) = "abs"(node)
 
 fun query(query: String) = Node.EMPTY + "(" + query + ")"
 
-fun property(name: String): PropertyNode = object : PropertyNode {
-	override fun format(table: TableStructure<*>): String = parseColumnSpecification(name, table).build()
+fun <T> property(name: String): PropertyNode<T> = object : PropertyNode<T> {
+	override fun format(table: TableStructure<*>, formatter: (ColumnInfo) -> String): String = formatter(parseColumnSpecification(name, table))
 	override fun columnContext(table: TableStructure<*>): ColumnInfo = parseColumnSpecification(name, table)
 }
 
-fun <T> value(value: T, type: KType, static: Boolean = false): ValueNode = object : ValueNode {
-	override fun format(table: TableStructure<*>): String = ":${ hashCode() }"
+fun <T> property(property: KProperty<*>, vararg reference: KProperty<*>) = property<T>((arrayOf(property) + reference).joinToString("->") { it.name })
+fun <T> property(property: KProperty<T>) = property<T>(property, *emptyArray())
+fun <T, I> property(property: KProperty1<*, I>, reference: KProperty1<I, T>) = property<T>(property, reference)
+fun <T, I1, I2> property(property: KProperty1<*, I1>, reference1: KProperty1<I1, I2>, reference2: KProperty1<I2, T>) = property<T>(property, reference1, reference2)
+
+inline fun <reified T> valueForProperty(property: KProperty<T>, value: T, static: Boolean = false) = valueForProperty(property, value, typeOf<T>(), static)
+fun <T> valueForProperty(property: KProperty<T>, value: T, type: KType, static: Boolean = false): PropertyNode<T> = object : PropertyNode<T>, ValueNode<T> {
+	override fun format(table: TableStructure<*>, formatter: (ColumnInfo) -> String): String = ":${ hashCode() }"
+
+	override fun values(table: TableStructure<*>, column: ColumnData<*, *>?): Map<String, Argument> {
+		@Suppress("UNCHECKED_CAST")
+		val manager = column?.takeIf { !static && it.type.isSubtypeOf(type) }?.mapper as TypeMapper<T, *>? ?: table.manager.getTypeMapper<T, Any>(type, column?.getRootColumn()?.property?.takeIf { !static }) ?: throw IllegalArgumentException("Cannot find suitable TypeMapper for $type")
+		return mapOf(hashCode().toString() to manager.write(column, table, type, value))
+	}
+
+	override fun columnContext(table: TableStructure<*>): ColumnInfo = parseColumnSpecification(property.name, table)
+}
+
+fun <T> value(value: T, type: KType, static: Boolean = false): ValueNode<T> = object : ValueNode<T> {
+	override fun format(table: TableStructure<*>, formatter: (ColumnInfo) -> String): String = ":${ hashCode() }"
 
 	override fun values(table: TableStructure<*>, column: ColumnData<*, *>?): Map<String, Argument> {
 		@Suppress("UNCHECKED_CAST")
@@ -49,38 +72,39 @@ fun <T> value(value: T, type: KType, static: Boolean = false): ValueNode = objec
 
 inline fun <reified T> value(value: T, static: Boolean = false) = value(value, typeOf<T>(), static)
 
-fun nullValue() = object : ValueNode {
-	override fun format(table: TableStructure<*>): String = "null"
+fun <T> nullValue() = object : ValueNode<T?> {
+	override fun format(table: TableStructure<*>, formatter: (ColumnInfo) -> String): String = "null"
 	override fun values(table: TableStructure<*>, column: ColumnData<*, *>?): Map<String, Argument> = emptyMap()
 }
 
-fun unsafeNode(string: String, values: Map<String, Argument> = emptyMap()) = object : Node {
-	override fun format(table: TableStructure<*>): String = string
+fun unsafeNode(string: String, values: Map<String, Argument> = emptyMap()) = object : Node<Any?> {
+	override fun format(table: TableStructure<*>, formatter: (ColumnInfo) -> String): String = string
 	override fun values(table: TableStructure<*>, column: ColumnData<*, *>?): Map<String, Argument> = values
 }
 
-interface Node {
+interface Node<T> {
 	companion object {
 		val EMPTY = unsafeNode("")
 	}
 
-	fun format(table: TableStructure<*>): String
+	fun format(table: TableStructure<*>, formatter: (ColumnInfo) -> String = { it.build() }): String
 	fun values(table: TableStructure<*>, column: ColumnData<*, *>?): Map<String, Argument>
 
 	fun columnContext(table: TableStructure<*>): ColumnInfo? = null
 
-	operator fun plus(string: String) = this + unsafeNode(string)
-	operator fun plus(node: Node) = object : Node {
-		override fun format(table: TableStructure<*>): String = this@Node.format(table) + node.format(table)
+	@Suppress("UNCHECKED_CAST")
+	operator fun plus(string: String): Node<T> = (this + unsafeNode(string)) as Node<T>
+	operator fun plus(node: Node<*>): Node<Any?> = object : Node<Any?> {
+		override fun format(table: TableStructure<*>, formatter: (ColumnInfo) -> String): String = this@Node.format(table, formatter) + node.format(table, formatter)
 		override fun values(table: TableStructure<*>, column: ColumnData<*, *>?): Map<String, Argument> = this@Node.values(table, column) + node.values(table, column)
 		override fun columnContext(table: TableStructure<*>): ColumnInfo? = this@Node.columnContext(table) ?: node.columnContext(table)
 	}
 }
 
-interface PropertyNode : Node {
+interface ValueNode<T> : Node<T>
+interface PropertyNode<T> : Node<T> {
 	override fun values(table: TableStructure<*>, column: ColumnData<*, *>?): Map<String, Argument> = emptyMap()
 }
-interface ValueNode : Node
 
 data class ColumnInfo(val column: ColumnData<*, *>, val context: Array<String> = emptyArray(), val transform: (String) -> String = { "\"$it\"" }) {
 	fun build(prefix: Boolean = true): String = "${ if (prefix) "\"${ context.takeIf { it.isNotEmpty() }?.joinToString(".") ?: column.table.name }\"." else "" }${ transform(column.name) }"
@@ -119,7 +143,7 @@ fun <T: Any> parseColumnSpecification(name: String, table: TableStructure<T>, co
 	}
 
 	else -> {
-		val column = columnFinder(name) ?: throw IllegalArgumentException("Column $name not found")
+		val column = columnFinder(name) ?: throw IllegalArgumentException("Column $name not found in ${ table.name }")
 		ColumnInfo(column)
 	}
 }

--- a/core/src/main/kotlin/de/mineking/database/Table.kt
+++ b/core/src/main/kotlin/de/mineking/database/Table.kt
@@ -4,11 +4,8 @@ import org.jdbi.v3.core.kotlin.useHandleUnchecked
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
-import kotlin.reflect.KClass
-import kotlin.reflect.KProperty1
-import kotlin.reflect.KType
+import kotlin.reflect.*
 import kotlin.reflect.jvm.javaField
-import kotlin.reflect.typeOf
 
 @Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
@@ -48,11 +45,15 @@ interface Table<T: Any> {
 	fun dropTable() = structure.manager.driver.useHandleUnchecked { it.createUpdate("drop table ${ structure.name }").execute() }
 
 	fun selectRowCount(where: Where = Where.EMPTY): Int
-	fun select(vararg columns: String, where: Where = Where.EMPTY, order: Order? = null, limit: Int? = null, offset: Int? = null): QueryResult<T>
-	fun <C> select(target: Node, type: KType, where: Where = Where.EMPTY, order: Order? = null, limit: Int? = null, offset: Int? = null): QueryResult<C>
+	fun <C> selectValue(target: Node<C>, type: KType, where: Where = Where.EMPTY, order: Order? = null, limit: Int? = null, offset: Int? = null): QueryResult<C>
+
+	fun select(vararg columns: Node<*>, where: Where = Where.EMPTY, order: Order? = null, limit: Int? = null, offset: Int? = null): QueryResult<T>
+	fun select(vararg columns: KProperty<*>, where: Where = Where.EMPTY, order: Order? = null, limit: Int? = null, offset: Int? = null): QueryResult<T> = select(columns = columns.map { property(it) }.toTypedArray(), where, order, limit, offset)
+	fun select(where: Where = Where.EMPTY, order: Order? = null, limit: Int? = null, offset: Int? = null): QueryResult<T> = select(columns = emptyArray<KProperty<*>>(), where, order, limit, offset)
 
 	fun update(obj: T): UpdateResult<T>
-	fun update(column: String, value: Node, where: Where = Where.EMPTY): UpdateResult<Int>
+	fun <T> update(column: Node<T>, value: Node<T>, where: Where = Where.EMPTY): UpdateResult<Int>
+	fun <T> update(column: KProperty<T>, value: Node<T>, where: Where = Where.EMPTY): UpdateResult<Int> = update(property(column), value, where)
 
 	fun insert(obj: T): UpdateResult<T>
 	fun upsert(obj: T): UpdateResult<T>
@@ -61,7 +62,7 @@ interface Table<T: Any> {
 	fun delete(obj: T) = delete(identifyObject(obj))
 }
 
-inline fun <reified T> Table<*>.select(target: Node, where: Where = Where.EMPTY, order: Order? = null, limit: Int? = null, offset: Int? = null): QueryResult<T> = select(target, typeOf<T>(), where, order, limit, offset)
+inline fun <reified T> Table<*>.selectValue(target: Node<T>, where: Where = Where.EMPTY, order: Order? = null, limit: Int? = null, offset: Int? = null): QueryResult<T> = selectValue(target, typeOf<T>(), where, order, limit, offset)
 
 abstract class TableImplementation<T: Any>(
 	val type: KClass<*>,

--- a/discord/src/test/kotlin/tests/discord/Discord.kt
+++ b/discord/src/test/kotlin/tests/discord/Discord.kt
@@ -85,12 +85,12 @@ class DiscordTest {
 
 	@Test
 	fun selectColumn() {
-		assertEquals(guilds[0], table.select<Guild>(property("guild")).first())
+		assertEquals(guilds[0], table.selectValue(property(DiscordDao::guild)).first())
 	}
 
 	@Test
 	fun selectCondition() {
-		assertEquals(1, table.selectRowCount(where = property("guild") isEqualTo value(guilds[0])))
-		assertEquals(0, table.selectRowCount(where = property("guild") isEqualTo value(guilds[1])))
+		assertEquals(1, table.selectRowCount(where = property(DiscordDao::guild) isEqualTo value(guilds[0])))
+		assertEquals(0, table.selectRowCount(where = property(DiscordDao::guild) isEqualTo value(guilds[1])))
 	}
 }

--- a/discord/src/test/kotlin/tests/discord/Snowflake.kt
+++ b/discord/src/test/kotlin/tests/discord/Snowflake.kt
@@ -46,12 +46,12 @@ class SnowflakeTest {
 
 	@Test
 	fun selectColumn() {
-		assertEquals(guilds[0], table.select<Guild>(property("snowflake")).first())
+		assertEquals(guilds[0], table.selectValue(property(SnowflakeDao::snowflake)).first())
 	}
 
 	@Test
 	fun selectCondition() {
-		assertEquals(1, table.selectRowCount(where = property("snowflake") isEqualTo value(guilds[0])))
-		assertEquals(0, table.selectRowCount(where = property("snowflake") isEqualTo value(guilds[1])))
+		assertEquals(1, table.selectRowCount(where = property(SnowflakeDao::snowflake) isEqualTo value(guilds[0])))
+		assertEquals(0, table.selectRowCount(where = property(SnowflakeDao::snowflake) isEqualTo value(guilds[1])))
 	}
 }

--- a/minecraft/src/test/kotlin/tests/minecraft/Color.kt
+++ b/minecraft/src/test/kotlin/tests/minecraft/Color.kt
@@ -42,9 +42,9 @@ class ColorTest {
 
 	@Test
 	fun selectColumn() {
-		assertEquals(TextColor.color(0x00ff00), table.select<TextColor>(property("color"), limit = 1).first())
-		assertEquals(NamedTextColor.GREEN, table.select<NamedTextColor>(property("namedColor"), limit = 1).first())
+		assertEquals(TextColor.color(0x00ff00), table.selectValue(property(ColorDao::color), limit = 1).first())
+		assertEquals(NamedTextColor.GREEN, table.selectValue(property(ColorDao::namedColor), limit = 1).first())
 
-		assertEquals(1, table.selectRowCount(where = property("color") isEqualTo value(TextColor.color(0x00ff00))))
+		assertEquals(1, table.selectRowCount(where = property(ColorDao::color) isEqualTo value(TextColor.color(0x00ff00))))
 	}
 }

--- a/minecraft/src/test/kotlin/tests/minecraft/Location.kt
+++ b/minecraft/src/test/kotlin/tests/minecraft/Location.kt
@@ -55,17 +55,17 @@ class LocationTest {
 
 	@Test
 	fun coordinates() {
-		assertEquals(1, table.selectRowCount(where = property("location1[0]") isEqualTo property("location1.x")))
-		assertEquals(0.0, table.select<Double>(property("location1.x")).first())
+		assertEquals(1, table.selectRowCount(where = property<Double>("location1[0]") isEqualTo property<Double>("location1.x")))
+		assertEquals(0.0, table.selectValue(property<Double>("location1.x")).first())
 	}
 
 	@Test
 	fun selectColumn() {
-		assertEquals(Location(worlds[0], 0.0, 5.0, 0.0), table.select<Location>(property("location1")).first())
+		assertEquals(Location(worlds[0], 0.0, 5.0, 0.0), table.selectValue(property(LocationDao::location1)).first())
 
-		assertEquals(id1, table.select<World>(property("location1.world")).first().uid)
+		assertEquals(id1, table.selectValue(property<World>("location1.world")).first().uid)
 
-		assertEquals(id2, table.select<World>(property("worldTest")).first().uid)
-		assertEquals(id2, table.select<World>(property("location2.world")).first().uid)
+		assertEquals(id2, table.selectValue(property(LocationDao::worldTest)).first().uid)
+		assertEquals(id2, table.selectValue(property<World>("location2.world")).first().uid)
 	}
 }

--- a/minecraft/src/test/kotlin/tests/minecraft/Player.kt
+++ b/minecraft/src/test/kotlin/tests/minecraft/Player.kt
@@ -52,9 +52,9 @@ class PlayerTest {
 
 	@Test
 	fun selectColumn() {
-		assertEquals(id1, table.select<OfflinePlayer>(property("player"), limit = 1).first().uniqueId)
+		assertEquals(id1, table.selectValue(property(PlayerDao::player), limit = 1).first().uniqueId)
 
-		assertEquals(1, table.selectRowCount(where = property("player") isEqualTo value(id1)))
-		assertEquals(1, table.selectRowCount(where = property("player") isEqualTo value(createPlayer(id1))))
+		assertEquals(1, table.selectRowCount(where = property(PlayerDao::player) isEqualTo value(id1)))
+		assertEquals(1, table.selectRowCount(where = property(PlayerDao::player) isEqualTo value(createPlayer(id1))))
 	}
 }

--- a/postgres/src/main/kotlin/de/mineking/database/vendors/postgres/Conditions.kt
+++ b/postgres/src/main/kotlin/de/mineking/database/vendors/postgres/Conditions.kt
@@ -6,9 +6,18 @@ import de.mineking.database.invoke
 import de.mineking.database.value
 import kotlin.reflect.typeOf
 
-fun arrayLength(node: Node) = "array_length"(node)
+@Suppress("UNCHECKED_CAST")
+operator fun <T, C> Node<C>.get(index: Node<Int>): Node<T> where C: Iterable<T> = (this + "[" + index + " + 1]") as Node<T>
 
-infix fun Node.matches(other: String) = Where(this + " ~ '" + other + "'")
-infix fun Node.contains(other: Node) = Where(other + " = any(" + this + ")")
+@Suppress("UNCHECKED_CAST")
+operator fun <T, C> Node<C>.get(index: Int): Node<T> where C: Iterable<T> = (this + "[" + value(index + 1) + "]") as Node<T>
 
-fun Node.json(vararg path: String) = this + " #>> " + value(path, typeOf<Array<String>>(), static = true)
+@Suppress("UNCHECKED_CAST")
+val <C> Node<C>.size where C: Iterable<*> get() = "array_length"(this, value(1)) as Node<Int>
+
+infix fun <T, C> Node<C>.contains(other: Node<T>) where C: Iterable<T> = Where(other + " = any(" + this + ")")
+
+infix fun Node<CharSequence>.matches(other: String) = Where(this + " ~ '" + other + "'")
+
+@Suppress("UNCHECKED_CAST")
+fun <T> Node<*>.json(vararg path: String) = (this + " #>> " + value(path, typeOf<Array<String>>(), static = true)) as Node<T>

--- a/postgres/src/main/kotlin/de/mineking/database/vendors/postgres/PostgresTable.kt
+++ b/postgres/src/main/kotlin/de/mineking/database/vendors/postgres/PostgresTable.kt
@@ -9,6 +9,7 @@ import org.jdbi.v3.core.statement.Update
 import org.postgresql.util.PSQLState
 import java.sql.SQLException
 import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 
 class PostgresTable<T: Any>(
@@ -91,38 +92,53 @@ class PostgresTable<T: Any>(
 		${ limit?.let { "limit $it" } ?: "" }
 	""".trim().replace("\\s+".toRegex(), " ")
 
-	override fun select(vararg columns: String, where: Where, order: Order?, limit: Int?, offset: Int?): QueryResult<T> {
-		fun createColumnList(columns: Collection<ColumnData<*, *>>, prefix: Array<String> = emptyArray()): List<Pair<String, String>> {
+	override fun select(vararg columns: Node<*>, where: Where, order: Order?, limit: Int?, offset: Int?): QueryResult<T> {
+		fun convert(columns: Collection<ColumnData<*, *>>): List<Node<Any>> = columns.flatMap { column -> when (column) {
+			is DirectColumnData -> convert(column.getChildren().filter { it.shouldCreate() }) + property(column.property.name)
+			is VirtualColumnData -> listOf(property("${ column.parent.property.name }.${ column.simpleName }"))
+			else -> error("")
+		} }
+		fun createColumnList(columns: Collection<Node<*>>, context: TableStructure<*>, prefix: Array<String> = emptyArray()): List<Pair<String, Pair<String, String>>> {
 			if (columns.isEmpty()) return emptyList()
-			return columns
-				.filterIsInstance<DirectColumnData<*, *>>()
-				.filter { it.reference != null }
-				.filter { !it.type.isArray() }
-				.flatMap { createColumnList(it.reference!!.structure.getAllColumns(), prefix + it.name) } +
-			columns.map { (prefix.joinToString(".").takeIf { it.isNotBlank() } ?: structure.name) to it.name }
+
+			return columns.flatMap {
+				val column = it.columnContext(context)!!.column
+
+				listOf(it.format(context) {
+					val temp = it.context.toMutableList()
+					if (temp.isNotEmpty()) temp.removeAt(0)
+					temp.addAll(0, prefix.toList())
+
+					it.copy(context = temp.toTypedArray()).build()
+				} to ((prefix.joinToString(".").takeIf { it.isNotBlank() } ?: structure.name) to column.name)) +
+					if (column is DirectColumnData && column.reference != null && !column.type.isArray()) createColumnList(convert(column.reference!!.structure.getAllColumns()), column.reference!!.structure, prefix + column.name)
+					else emptyList()
+			}
 		}
 
 		val columnList = createColumnList(
-			if (columns.isEmpty()) structure.getAllColumns()
-			else columns.map { parseColumnSpecification(it, structure).column }.toSet()
+			if (columns.isEmpty()) convert(structure.getAllColumns())
+			else columns.toSet(),
+			structure
 		)
 
-		val sql = createSelect(columnList.joinToString { "\"${ it.first }\".\"${ it.second }\" as \"${ it.first }.${ it.second }\"" }, where, order, limit, offset)
+		val sql = createSelect(columnList.joinToString { (value, name) -> "$value as \"${ name.first }.${ name.second }\"" }, where, order, limit, offset)
 		return object : SimpleQueryResult<T> {
 			override fun <O> execute(handler: (ResultIterable<T>) -> O): O = structure.manager.execute { handler(it.createQuery(sql)
+				.bindMap(columns.flatMap { it.values(structure, it.columnContext(structure)?.column).entries }.associate { it.toPair() })
 				.bindMap(where.values(structure))
 				.map { set, _ ->
 					val instance = instance()
-					parseResult(ReadContext(instance, structure, set, columnList.map { "${ it.first }.${ it.second }" }))
+					parseResult(ReadContext(instance, structure, set, columnList.map { (_, name) -> "${ name.first }.${ name.second }" }))
 					instance
 				}
 			) }
 		}
 	}
 
-	override fun <C> select(target: Node, type: KType, where: Where, order: Order?, limit: Int?, offset: Int?): QueryResult<C> {
+	override fun <C> selectValue(target: Node<C>, type: KType, where: Where, order: Order?, limit: Int?, offset: Int?): QueryResult<C> {
 		val column = target.columnContext(structure)
-		val mapper = structure.manager.getTypeMapper<C, Any>(type, column?.column?.getRootColumn()?.property) ?: throw IllegalArgumentException("No suitable TypeMapper found")
+		val mapper = structure.manager.getTypeMapper<C, Any>(type, column?.column?.getRootColumn()?.property) ?: throw IllegalArgumentException("No suitable TypeMapper found for $type")
 
 		fun createColumnList(columns: List<ColumnData<*, *>>, prefix: Array<String> = emptyArray()): List<Pair<String, String>> {
 			if (columns.isEmpty()) return emptyList()
@@ -194,19 +210,20 @@ class PostgresTable<T: Any>(
 		}
 	}
 
-	override fun update(column: String, value: Node, where: Where): UpdateResult<Int > {
-		val spec = parseColumnSpecification(column, structure)
+	override fun <T> update(column: Node<T>, value: Node<T>, where: Where): UpdateResult<Int > {
+		val spec = column.columnContext(structure)!!
 
 		require(spec.context.isEmpty()) { "Cannot update reference, update in the table directly" }
 		require(!spec.column.getRootColumn().key) { "Cannot update key" }
 
 		val sql = """
 			update ${ structure.name } 
-			set ${ spec.build(false) } = ${ value.format(structure) }
+			set ${ column.format(structure) { it.build(prefix = false) }} = ${ value.format(structure) }
 			${ where.format(structure) } 
 		""".trim().replace("\\s+".toRegex(), " ")
 
 		return createResult { structure.manager.execute { it.createUpdate(sql)
+			.bindMap(column.values(structure, spec.column))
 			.bindMap(value.values(structure, spec.column))
 			.bindMap(where.values(structure))
 			.execute()

--- a/postgres/src/test/kotlin/tests/postgres/general/Delete.kt
+++ b/postgres/src/test/kotlin/tests/postgres/general/Delete.kt
@@ -38,7 +38,7 @@ class DeleteTest {
 
     @Test
     fun deleteCondition() {
-        assertEquals(2, table.delete(where = property("age").isBetween(value(18), value(25))))
+        assertEquals(2, table.delete(where = property(UserDao::age).isBetween(value(18), value(25))))
         assertEquals(3, table.selectRowCount())
     }
 }

--- a/postgres/src/test/kotlin/tests/postgres/general/Select.kt
+++ b/postgres/src/test/kotlin/tests/postgres/general/Select.kt
@@ -41,13 +41,13 @@ class SelectTest {
 
 	@Test
 	fun selectBetween() {
-		assertEquals(2, table.selectRowCount(where = property("age").isBetween(value(18), value(25))))
-		assertEquals(2, table.select(where = property("age").isBetween(value(18), value(25))).list().size)
+		assertEquals(2, table.selectRowCount(where = property(UserDao::age).isBetween(value(18), value(25))))
+		assertEquals(2, table.select(where = property(UserDao::age).isBetween(value(18), value(25))).list().size)
 	}
 
 	@Test
 	fun selectSingle() {
-		val result = table.select(where = property("name") isEqualTo value("Max")).list()
+		val result = table.select(where = property(UserDao::name) isEqualTo value("Max")).list()
 
 		assertEquals(1, result.size)
 
@@ -57,7 +57,7 @@ class SelectTest {
 
 	@Test
 	fun selectSpecifiedColumns() {
-		val result = table.select("email", "name", where = property("name") isEqualTo value("Max")).list()
+		val result = table.select(UserDao::email, UserDao::name, where = property(UserDao::name) isEqualTo value("Max")).list()
 
 		assertEquals(1, result.size)
 
@@ -66,26 +66,38 @@ class SelectTest {
 	}
 
 	@Test
+	fun selectComplexSpecifiedColumns() {
+		val result = table.select(property(UserDao::name).uppercase(), valueForProperty(UserDao::age, Integer.MAX_VALUE), where = property(UserDao::name) isEqualTo value("Max")).list()
+
+		assertEquals(1, result.size)
+
+		assertEquals("MAX", result.first().name)
+		assertEquals(Integer.MAX_VALUE, result.first().age) //Age has the default value (0)
+	}
+
+	@Test
 	fun selectColumn() {
-		val result = table.select<Int>(property("age"), where = property("name") isEqualTo value("Max")).list()
+		val result = table.selectValue(property(UserDao::age), where = property(UserDao::name) isEqualTo value("Max")).list()
 
 		assertEquals(1, result.size)
 		assertEquals(20, result.first())
+
+		assertEquals(3, table.selectValue(property(UserDao::name).length(), where = property(UserDao::name) isEqualTo value("Max")).first())
 	}
 
 	@Test
 	fun selectComplex() {
-		assertEquals(42, table.select<Int>(value(42), where = property("name") isEqualTo value("Max")).first())
+		assertEquals(42, table.selectValue(value(42), where = property(UserDao::name) isEqualTo value("Max")).first())
 
-		assertEquals(21, table.select<Int>(property("age") + " + 1", where = property("name") isEqualTo value("Max")).first())
-		assertEquals(40, table.select<Int>(property("age") + " * 2", where = property("name") isEqualTo value("Max")).first())
+		assertEquals(21, table.selectValue(property(UserDao::age) + " + 1", where = property(UserDao::name) isEqualTo value("Max")).first())
+		assertEquals(40, table.selectValue(property(UserDao::age) + " * 2", where = property(UserDao::name) isEqualTo value("Max")).first())
 
-		assertEquals("MAX", table.select<String>(upperCase(property("name")), where = property("name") isEqualTo value("Max")).first())
+		assertEquals("MAX", table.selectValue(property(UserDao::name).uppercase(), where = property(UserDao::name) isEqualTo value("Max")).first())
 	}
 
 	@Test
 	fun limit() {
-		val result = table.select<String>(property("name"), limit = 2).list()
+		val result = table.selectValue(property(UserDao::name), limit = 2).list()
 
 		assertEquals(2, result.size)
 		assertContains(result, "Tom")
@@ -94,7 +106,7 @@ class SelectTest {
 
 	@Test
 	fun offset() {
-		val result = table.select<String>(property("name"), limit = 1, offset = 1).list()
+		val result = table.selectValue(property(UserDao::name), limit = 1, offset = 1).list()
 
 		assertEquals(1, result.size)
 		assertContains(result, "Alex")
@@ -102,17 +114,17 @@ class SelectTest {
 
 	@Test
 	fun order() {
-		val result1 = table.select<String>(property("name"), order = ascendingBy("id")).list()
+		val result1 = table.selectValue(property(UserDao::name), order = ascendingBy(UserDao::id)).list()
 
 		assertEquals("Tom", result1[0])
 		assertEquals("Max", result1[4])
 
-		val result2 = table.select<String>(property("name"), order = descendingBy("id")).list()
+		val result2 = table.selectValue(property(UserDao::name), order = descendingBy(UserDao::id)).list()
 
 		assertEquals("Max", result2[0])
 		assertEquals("Tom", result2[4])
 
-		val result3 = table.select<String>(property("name"), order = ascendingBy("name")).list()
+		val result3 = table.selectValue(property(UserDao::name), order = ascendingBy(UserDao::name)).list()
 
 		assertEquals("Alex", result3[0])
 		assertEquals("Tom", result3[4])

--- a/postgres/src/test/kotlin/tests/postgres/general/Update.kt
+++ b/postgres/src/test/kotlin/tests/postgres/general/Update.kt
@@ -1,9 +1,6 @@
 package tests.postgres.general
 
-import de.mineking.database.isEqualTo
-import de.mineking.database.property
-import de.mineking.database.select
-import de.mineking.database.value
+import de.mineking.database.*
 import de.mineking.database.vendors.postgres.PostgresConnection
 import org.junit.jupiter.api.Test
 import setup.ConsoleSqlLogger
@@ -34,13 +31,13 @@ class UpdateTest {
 
     @Test
     fun updateName() {
-        assertEquals(1, table.update("name", value("Test"), where = property("id") isEqualTo value(1)).value)
-        assertEquals("Test", table.select<String>(property("name"), where = property("id") isEqualTo value(1)).first())
+        assertEquals(1, table.update(UserDao::name, value("Test"), where = property(UserDao::id) isEqualTo value(1)).value)
+        assertEquals("Test", table.selectValue(property(UserDao::name), where = property(UserDao::id) isEqualTo value(1)).first())
     }
 
     @Test
     fun updateConflict() {
-        val result = table.update("email", value("max@example.com"), where = property("id") isEqualTo value(1))
+        val result = table.update(UserDao::email, value("max@example.com"), where = property(UserDao::id) isEqualTo value(1))
 
         assertTrue(result.isError())
         assertTrue(result.uniqueViolation)

--- a/postgres/src/test/kotlin/tests/postgres/general/Upsert.kt
+++ b/postgres/src/test/kotlin/tests/postgres/general/Upsert.kt
@@ -43,12 +43,12 @@ class UpsertTest {
 	@Test
 	fun update() {
 		assertTrue(table.upsert(entries[0].copy(name = "Test")).isSuccess())
-		assertEquals("Test", table.select<String>(property("name"), where = property("id1") isEqualTo value(1)).first())
+		assertEquals("Test", table.selectValue(property(UpsertDao::name), where = property(UpsertDao::id1) isEqualTo value(1)).first())
 	}
 
 	@Test
 	fun notUpdated() {
 		assertTrue(table.upsert(entries[0].copy(email = "alex@example.com")).isError())
-		assertEquals("tom@example.com", table.select<String>(property("email"), where = property("id1") isEqualTo value(1)).first())
+		assertEquals("tom@example.com", table.selectValue(property(UpsertDao::email), where = property(UpsertDao::id1) isEqualTo value(1)).first())
 	}
 }

--- a/postgres/src/test/kotlin/tests/postgres/reference/Reference.kt
+++ b/postgres/src/test/kotlin/tests/postgres/reference/Reference.kt
@@ -78,19 +78,19 @@ class ReferenceTest {
 
 	@Test
 	fun selectSingleReference() {
-		assertEquals(2, bookTable.select(where = property("author->name") isEqualTo value("William Shakespeare")).list().size)
-		assertEquals(3, bookTable.select(where = property("author->name") isEqualTo value("J.R.R. Tolkien")).list().size)
+		assertEquals(2, bookTable.select(where = property(BookDao::author, AuthorDao::name) isEqualTo value("William Shakespeare")).list().size)
+		assertEquals(3, bookTable.select(where = property(BookDao::author, AuthorDao::name) isEqualTo value("J.R.R. Tolkien")).list().size)
 	}
 
 	@Test
 	fun selectDoubleReference() {
-		assertEquals(2, bookTable.select(where = property("author->publisher->name") isEqualTo value("A")).list().size)
-		assertEquals(3, bookTable.select(where = property("author->publisher->name") isEqualTo value("B")).list().size)
+		assertEquals(2, bookTable.select(where = property(BookDao::author, AuthorDao::publisher, PublisherDao::name) isEqualTo value("A")).list().size)
+		assertEquals(3, bookTable.select(where = property(BookDao::author, AuthorDao::publisher, PublisherDao::name) isEqualTo value("B")).list().size)
 	}
 
 	@Test
 	fun selectSingle() {
-		val result = bookTable.select<String>(upperCase(property("title")), where = property("publisher") isNotEqualTo property("author->publisher")).list()
+		val result = bookTable.selectValue(property(BookDao::title).uppercase(), where = property(BookDao::publisher) isNotEqualTo property(BookDao::author, AuthorDao::publisher)).list()
 
 		assertEquals(1, result.size)
 		assertEquals("THE HOBBIT", result.first())
@@ -98,12 +98,12 @@ class ReferenceTest {
 
 	@Test
 	fun selectReference() {
-		assertEquals(tolkien, bookTable.select<AuthorDao>(property("author"), where = property("title") isEqualTo value("The Hobbit")).first())
+		assertEquals(tolkien, bookTable.selectValue(property(BookDao::author), where = property(BookDao::title) isEqualTo value("The Hobbit")).first())
 	}
 
 	@Test
 	fun updateReference() {
-		bookTable.update("publisher", value(publisherB), where = property("title") isEqualTo value("The Hobbit"))
-		assertEquals(publisherB, bookTable.select<PublisherDao>(property("publisher"), where = property("title") isEqualTo value("The Hobbit")).first())
+		bookTable.update(BookDao::publisher, value(publisherB), where = property(BookDao::title) isEqualTo value("The Hobbit"))
+		assertEquals(publisherB, bookTable.selectValue(property(BookDao::publisher), where = property(BookDao::title) isEqualTo value("The Hobbit")).first())
 	}
 }

--- a/postgres/src/test/kotlin/tests/postgres/reference/ReferenceArray.kt
+++ b/postgres/src/test/kotlin/tests/postgres/reference/ReferenceArray.kt
@@ -69,7 +69,7 @@ class ReferenceArrayTest {
 
 	@Test
 	fun selectContains() {
-		assertEquals(1, referenceTable.selectRowCount(where = property("books") contains value(romeoAndJulia)))
-		assertEquals(2, referenceTable.selectRowCount(where = property("books") contains value(hamlet)))
+		assertEquals(1, referenceTable.selectRowCount(where = property(ReferenceArrayDao::books) contains value(romeoAndJulia)))
+		assertEquals(2, referenceTable.selectRowCount(where = property(ReferenceArrayDao::books) contains value(hamlet)))
 	}
 }

--- a/postgres/src/test/kotlin/tests/postgres/specific/Color.kt
+++ b/postgres/src/test/kotlin/tests/postgres/specific/Color.kt
@@ -27,6 +27,6 @@ class ColorTest {
 
 	@Test
 	fun selectAll() {
-		assertEquals(Color.GREEN, table.select<Color>(property("color")).first())
+		assertEquals(Color.GREEN, table.selectValue(property(ColorDao::color)).first())
 	}
 }

--- a/postgres/src/test/kotlin/tests/postgres/specific/Date.kt
+++ b/postgres/src/test/kotlin/tests/postgres/specific/Date.kt
@@ -33,7 +33,7 @@ class DateTest {
 
 	@Test
 	fun selectAll() {
-		assertEquals(time.truncatedTo(ChronoUnit.MILLIS), table.select<Instant>(property("time")).first().truncatedTo(ChronoUnit.MILLIS))
-		assertEquals(date, table.select<LocalDate>(property("date")).first())
+		assertEquals(time.truncatedTo(ChronoUnit.MILLIS), table.selectValue(property(DateDao::time)).first().truncatedTo(ChronoUnit.MILLIS))
+		assertEquals(date, table.selectValue(property(DateDao::date)).first())
 	}
 }

--- a/postgres/src/test/kotlin/tests/postgres/specific/Enum.kt
+++ b/postgres/src/test/kotlin/tests/postgres/specific/Enum.kt
@@ -41,6 +41,6 @@ class EnumTest {
 
 	@Test
 	fun selectSingle() {
-		assertEquals(TestEnum.A, table.select<TestEnum>(property("single")).first())
+		assertEquals(TestEnum.A, table.selectValue(property(EnumDao::single)).first())
 	}
 }

--- a/postgres/src/test/kotlin/tests/postgres/specific/Json.kt
+++ b/postgres/src/test/kotlin/tests/postgres/specific/Json.kt
@@ -36,11 +36,11 @@ class JsonTest {
 
 	@Test
 	fun selectSingle() {
-		assertEquals(linkedMapOf("a" to "b", "b" to "a"), table.select<LinkedHashMap<String, String>>(property("map1")).first())
+		assertEquals(linkedMapOf("a" to "b", "b" to "a"), table.selectValue(property(JsonDao::map1)).first())
 	}
 
 	@Test
 	fun selectChild() {
-		assertEquals("b", table.select<String>(property("map1").json("a")).first())
+		assertEquals("b", table.selectValue(property(JsonDao::map1).json<String>("a")).first())
 	}
 }

--- a/postgres/src/test/kotlin/tests/postgres/specific/Locale.kt
+++ b/postgres/src/test/kotlin/tests/postgres/specific/Locale.kt
@@ -27,6 +27,6 @@ class LocaleTest {
 
 	@Test
 	fun selectAll() {
-		assertEquals(Locale.GERMAN, table.select<Locale>(property("locale")).first())
+		assertEquals(Locale.GERMAN, table.selectValue(property(LocaleDao::locale)).first())
 	}
 }

--- a/postgres/src/test/kotlin/tests/postgres/specific/Null.kt
+++ b/postgres/src/test/kotlin/tests/postgres/specific/Null.kt
@@ -29,7 +29,7 @@ class NullTest {
 
 	@Test
 	fun selectAll() {
-		val result = table.select<String?>(property("test")).list()
+		val result = table.selectValue(property(NullDao::test)).list()
 
 		assertEquals(2, result.size)
 
@@ -39,8 +39,8 @@ class NullTest {
 
 	@Test
 	fun selectIsNull() {
-		assertEquals("not-null", table.select<String>(property("name"), where = property("test").isNotNull()).first())
-		assertEquals("null", table.select<String>(property("name"), where = property("test").isNull()).first())
+		assertEquals("not-null", table.selectValue(property(NullDao::name), where = property(NullDao::test).isNotNull()).first())
+		assertEquals("null", table.selectValue(property(NullDao::name), where = property(NullDao::test).isNull()).first())
 	}
 
 	@Test
@@ -50,17 +50,17 @@ class NullTest {
 			assertTrue(result.notNullViolation)
 		}
 
-		checkResult(table.update("name", value<String?>(null), where = property("id") isEqualTo value(1)))
-		checkResult(table.update("name", nullValue(), where = property("id") isEqualTo value(1)))
+		checkResult(table.update(NullDao::name, value(null), where = property(NullDao::id) isEqualTo value(1)))
+		checkResult(table.update(NullDao::name, nullValue(), where = property(NullDao::id) isEqualTo value(1)))
 	}
 
 	@Test
 	fun updateNull() {
-		val result = table.update("test", nullValue(), where = property("id") isEqualTo value(1))
+		val result = table.update(NullDao::test, nullValue(), where = property(NullDao::id) isEqualTo value(1))
 
 		assertTrue(result.isSuccess())
 		assertEquals(1, result.value)
 
-		assertEquals(null, table.select<String?>(property("test"), where = property("id") isEqualTo value(1)).first())
+		assertEquals(null, table.selectValue(property(NullDao::test), where = property(NullDao::id) isEqualTo value(1)).first())
 	}
 }

--- a/postgres/src/test/kotlin/tests/postgres/table/CustomTable.kt
+++ b/postgres/src/test/kotlin/tests/postgres/table/CustomTable.kt
@@ -15,9 +15,9 @@ import kotlin.test.assertTrue
 
 interface UserTable : Table<UserDao> {
     fun createUser(name: String, email: String, age: Int): UserDao = insert(UserDao(name = name, email = email, age = age)).getOrThrow()
-    fun getUserByEmail(email: String): UserDao? = select(where = property("email") isEqualTo value(email)).findFirst()
+    fun getUserByEmail(email: String): UserDao? = select(where = property(UserDao::email) isEqualTo value(email)).findFirst()
 
-    fun updateName(email: String, name: String) = (update("name", value(name), where = property("email") isEqualTo value(email)).value ?: 0) > 0
+    fun updateName(email: String, name: String) = (update(UserDao::name, value(name), where = property(UserDao::email) isEqualTo value(email)).value ?: 0) > 0
 }
 
 class CustomTableTest {

--- a/postgres/src/test/kotlin/tests/postgres/table/DataObject.kt
+++ b/postgres/src/test/kotlin/tests/postgres/table/DataObject.kt
@@ -49,14 +49,14 @@ class DataObjectTest {
 		val result = table.select().list()
 
 		assertEquals(2, result.size)
-		assertEquals(2, result[0].selectReferring(referenceTable, "reference").list().size)
-		assertEquals(3, result[1].selectReferring(referenceTable, "reference").list().size)
+		assertEquals(2, result[0].selectReferring(referenceTable, DataObjectReferenceDao::reference).list().size)
+		assertEquals(3, result[1].selectReferring(referenceTable, DataObjectReferenceDao::reference).list().size)
 	}
 
 	@Test
 	fun update() {
 		assertTrue(referenceTable.update(references[1].copy(reference = 1)).isSuccess())
 
-		assertEquals(3, table.select(where = property("name") isEqualTo value("A")).first().selectReferring(referenceTable, "reference").list().size)
+		assertEquals(3, table.select(where = property(DataObjectDao::name) isEqualTo value("A")).first().selectReferring(referenceTable, DataObjectReferenceDao::reference).list().size)
 	}
 }

--- a/sqlite/src/main/kotlin/de/mineking/database/vendors/sqlite/SQLiteTypes.kt
+++ b/sqlite/src/main/kotlin/de/mineking/database/vendors/sqlite/SQLiteTypes.kt
@@ -144,7 +144,7 @@ object SQLiteMappers {
 				val key = column.reference!!.structure.getKeys()[0] as ColumnData<Any, Any>
 
 				val ids = array.map { key.mapper.readFromBinary(column, key.type, it, context, name) }
-				val rows = column.reference!!.select(where = property(key.name).isIn(ids.map { value(it, key.type) })).list().associateBy { key.get(it) }
+				val rows = column.reference!!.select(where = property<Any>(key.name).isIn(ids.map { value(it, key.type) })).list().associateBy { key.get(it) }
 				println(rows)
 
 				return type.createCollection(ids.map { rows[it] }.asArray())

--- a/sqlite/src/test/kotlin/tests/sqlite/general/Delete.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/general/Delete.kt
@@ -38,7 +38,7 @@ class DeleteTest {
 
     @Test
     fun deleteCondition() {
-        assertEquals(2, table.delete(where = property("age").isBetween(value(18), value(25))))
+        assertEquals(2, table.delete(where = property(UserDao::age).isBetween(value(18), value(25))))
         assertEquals(3, table.selectRowCount())
     }
 }

--- a/sqlite/src/test/kotlin/tests/sqlite/general/Select.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/general/Select.kt
@@ -41,13 +41,13 @@ class SelectTest {
 
 	@Test
 	fun selectBetween() {
-		assertEquals(2, table.selectRowCount(where = property("age").isBetween(value(18), value(25))))
-		assertEquals(2, table.select(where = property("age").isBetween(value(18), value(25))).list().size)
+		assertEquals(2, table.selectRowCount(where = property(UserDao::age).isBetween(value(18), value(25))))
+		assertEquals(2, table.select(where = property(UserDao::age).isBetween(value(18), value(25))).list().size)
 	}
 
 	@Test
 	fun selectSingle() {
-		val result = table.select(where = property("name") isEqualTo value("Max")).list()
+		val result = table.select(where = property(UserDao::name) isEqualTo value("Max")).list()
 
 		assertEquals(1, result.size)
 
@@ -57,7 +57,7 @@ class SelectTest {
 
 	@Test
 	fun selectSpecifiedColumns() {
-		val result = table.select("email", "name", where = property("name") isEqualTo value("Max")).list()
+		val result = table.select(UserDao::email, UserDao::name, where = property(UserDao::name) isEqualTo value("Max")).list()
 
 		assertEquals(1, result.size)
 
@@ -66,26 +66,38 @@ class SelectTest {
 	}
 
 	@Test
+	fun selectComplexSpecifiedColumns() {
+		val result = table.select(property(UserDao::name).uppercase(), valueForProperty(UserDao::age, Integer.MAX_VALUE), where = property(UserDao::name) isEqualTo value("Max")).list()
+
+		assertEquals(1, result.size)
+
+		assertEquals("MAX", result.first().name)
+		assertEquals(Integer.MAX_VALUE, result.first().age) //Age has the default value (0)
+	}
+
+	@Test
 	fun selectColumn() {
-		val result = table.select<Int>(property("age"), where = property("name") isEqualTo value("Max")).list()
+		val result = table.selectValue(property(UserDao::age), where = property(UserDao::name) isEqualTo value("Max")).list()
 
 		assertEquals(1, result.size)
 		assertEquals(20, result.first())
+
+		assertEquals(3, table.selectValue(property(UserDao::name).length(), where = property(UserDao::name) isEqualTo value("Max")).first())
 	}
 
 	@Test
 	fun selectComplex() {
-		assertEquals(42, table.select<Int>(value(42), where = property("name") isEqualTo value("Max")).first())
+		assertEquals(42, table.selectValue(value(42), where = property(UserDao::name) isEqualTo value("Max")).first())
 
-		assertEquals(21, table.select<Int>(property("age") + " + 1", where = property("name") isEqualTo value("Max")).first())
-		assertEquals(40, table.select<Int>(property("age") + " * 2", where = property("name") isEqualTo value("Max")).first())
+		assertEquals(21, table.selectValue(property(UserDao::age) + " + 1", where = property(UserDao::name) isEqualTo value("Max")).first())
+		assertEquals(40, table.selectValue(property(UserDao::age) + " * 2", where = property(UserDao::name) isEqualTo value("Max")).first())
 
-		assertEquals("MAX", table.select<String>(upperCase(property("name")), where = property("name") isEqualTo value("Max")).first())
+		assertEquals("MAX", table.selectValue(property(UserDao::name).uppercase(), where = property(UserDao::name) isEqualTo value("Max")).first())
 	}
 
 	@Test
 	fun limit() {
-		val result = table.select<String>(property("name"), limit = 2).list()
+		val result = table.selectValue(property(UserDao::name), limit = 2).list()
 
 		assertEquals(2, result.size)
 		assertContains(result, "Tom")
@@ -94,7 +106,7 @@ class SelectTest {
 
 	@Test
 	fun offset() {
-		val result = table.select<String>(property("name"), limit = 1, offset = 1).list()
+		val result = table.selectValue(property(UserDao::name), limit = 1, offset = 1).list()
 
 		assertEquals(1, result.size)
 		assertContains(result, "Alex")
@@ -102,17 +114,17 @@ class SelectTest {
 
 	@Test
 	fun order() {
-		val result1 = table.select<String>(property("name"), order = ascendingBy("id")).list()
+		val result1 = table.selectValue(property(UserDao::name), order = ascendingBy(UserDao::id)).list()
 
 		assertEquals("Tom", result1[0])
 		assertEquals("Max", result1[4])
 
-		val result2 = table.select<String>(property("name"), order = descendingBy("id")).list()
+		val result2 = table.selectValue(property(UserDao::name), order = descendingBy(UserDao::id)).list()
 
 		assertEquals("Max", result2[0])
 		assertEquals("Tom", result2[4])
 
-		val result3 = table.select<String>(property("name"), order = ascendingBy("name")).list()
+		val result3 = table.selectValue(property(UserDao::name), order = ascendingBy(UserDao::name)).list()
 
 		assertEquals("Alex", result3[0])
 		assertEquals("Tom", result3[4])

--- a/sqlite/src/test/kotlin/tests/sqlite/general/Update.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/general/Update.kt
@@ -1,9 +1,6 @@
 package tests.sqlite.general
 
-import de.mineking.database.isEqualTo
-import de.mineking.database.property
-import de.mineking.database.select
-import de.mineking.database.value
+import de.mineking.database.*
 import de.mineking.database.vendors.sqlite.SQLiteConnection
 import org.junit.jupiter.api.Test
 import setup.ConsoleSqlLogger
@@ -34,13 +31,13 @@ class UpdateTest {
 
     @Test
     fun updateName() {
-        assertEquals(1, table.update("name", value("Test"), where = property("id") isEqualTo value(1)).value)
-        assertEquals("Test", table.select<String>(property("name"), where = property("id") isEqualTo value(1)).first())
+        assertEquals(1, table.update(UserDao::name, value("Test"), where = property(UserDao::id) isEqualTo value(1)).value)
+        assertEquals("Test", table.selectValue(property(UserDao::name), where = property(UserDao::id) isEqualTo value(1)).first())
     }
 
     @Test
     fun updateConflict() {
-        val result = table.update("email", value("max@example.com"), where = property("id") isEqualTo value(1))
+        val result = table.update(UserDao::email, value("max@example.com"), where = property(UserDao::id) isEqualTo value(1))
 
         assertTrue(result.isError())
         assertTrue(result.uniqueViolation)

--- a/sqlite/src/test/kotlin/tests/sqlite/general/Upsert.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/general/Upsert.kt
@@ -4,6 +4,7 @@ import de.mineking.database.*
 import de.mineking.database.vendors.sqlite.SQLiteConnection
 import org.junit.jupiter.api.Test
 import setup.ConsoleSqlLogger
+import setup.UserDao
 import setup.recreate
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -44,12 +45,12 @@ class UpsertTest {
 	@Test
 	fun update() {
 		assertTrue(table.upsert(entries[0].copy(name = "Test")).isSuccess())
-		assertEquals("Test", table.select<String>(property("name"), where = property("id1") isEqualTo value(1)).first())
+		assertEquals("Test", table.selectValue(property(UpsertDao::name), where = property(UpsertDao::id1) isEqualTo value(1)).first())
 	}
 
 	@Test
 	fun notUpdated() {
 		assertTrue(table.upsert(entries[0].copy(email = "alex@example.com")).isError())
-		assertEquals("tom@example.com", table.select<String>(property("email"), where = property("id1") isEqualTo value(1)).first())
+		assertEquals("tom@example.com", table.selectValue(property(UpsertDao::email), where = property(UpsertDao::id1) isEqualTo value(1)).first())
 	}
 }

--- a/sqlite/src/test/kotlin/tests/sqlite/reference/Reference.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/reference/Reference.kt
@@ -78,19 +78,19 @@ class ReferenceTest {
 
 	@Test
 	fun selectSingleReference() {
-		assertEquals(2, bookTable.select(where = property("author->name") isEqualTo value("William Shakespeare")).list().size)
-		assertEquals(3, bookTable.select(where = property("author->name") isEqualTo value("J.R.R. Tolkien")).list().size)
+		assertEquals(2, bookTable.select(where = property(BookDao::author, AuthorDao::name) isEqualTo value("William Shakespeare")).list().size)
+		assertEquals(3, bookTable.select(where = property(BookDao::author, AuthorDao::name) isEqualTo value("J.R.R. Tolkien")).list().size)
 	}
 
 	@Test
 	fun selectDoubleReference() {
-		assertEquals(2, bookTable.select(where = property("author->publisher->name") isEqualTo value("A")).list().size)
-		assertEquals(3, bookTable.select(where = property("author->publisher->name") isEqualTo value("B")).list().size)
+		assertEquals(2, bookTable.select(where = property(BookDao::author, AuthorDao::publisher, PublisherDao::name) isEqualTo value("A")).list().size)
+		assertEquals(3, bookTable.select(where = property(BookDao::author, AuthorDao::publisher, PublisherDao::name) isEqualTo value("B")).list().size)
 	}
 
 	@Test
 	fun selectSingle() {
-		val result = bookTable.select<String>(upperCase(property("title")), where = property("publisher") isNotEqualTo property("author->publisher")).list()
+		val result = bookTable.selectValue(property(BookDao::title).uppercase(), where = property(BookDao::publisher) isNotEqualTo property(BookDao::author, AuthorDao::publisher)).list()
 
 		assertEquals(1, result.size)
 		assertEquals("THE HOBBIT", result.first())
@@ -98,12 +98,12 @@ class ReferenceTest {
 
 	@Test
 	fun selectReference() {
-		assertEquals(tolkien, bookTable.select<AuthorDao>(property("author"), where = property("title") isEqualTo value("The Hobbit")).first())
+		assertEquals(tolkien, bookTable.selectValue(property(BookDao::author), where = property(BookDao::title) isEqualTo value("The Hobbit")).first())
 	}
 
 	@Test
 	fun updateReference() {
-		bookTable.update("publisher", value(publisherB), where = property("title") isEqualTo value("The Hobbit"))
-		assertEquals(publisherB, bookTable.select<PublisherDao>(property("publisher"), where = property("title") isEqualTo value("The Hobbit")).first())
+		bookTable.update(BookDao::publisher, value(publisherB), where = property(BookDao::title) isEqualTo value("The Hobbit"))
+		assertEquals(publisherB, bookTable.selectValue(property(BookDao::publisher), where = property(BookDao::title) isEqualTo value("The Hobbit")).first())
 	}
 }

--- a/sqlite/src/test/kotlin/tests/sqlite/specific/Color.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/specific/Color.kt
@@ -27,6 +27,6 @@ class ColorTest {
 
 	@Test
 	fun selectAll() {
-		assertEquals(Color.GREEN, table.select<Color>(property("color")).first())
+		assertEquals(Color.GREEN, table.selectValue(property(ColorDao::color)).first())
 	}
 }

--- a/sqlite/src/test/kotlin/tests/sqlite/specific/Date.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/specific/Date.kt
@@ -33,7 +33,7 @@ class DateTest {
 
 	@Test
 	fun selectAll() {
-		assertEquals(time.truncatedTo(ChronoUnit.MILLIS), table.select<Instant>(property("time")).first().truncatedTo(ChronoUnit.MILLIS))
-		assertEquals(date, table.select<LocalDate>(property("date")).first())
+		assertEquals(time.truncatedTo(ChronoUnit.MILLIS), table.selectValue(property(DateDao::time)).first().truncatedTo(ChronoUnit.MILLIS))
+		assertEquals(date, table.selectValue(property(DateDao::date)).first())
 	}
 }

--- a/sqlite/src/test/kotlin/tests/sqlite/specific/Enum.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/specific/Enum.kt
@@ -41,6 +41,6 @@ class EnumTest {
 
 	@Test
 	fun selectSingle() {
-		assertEquals(TestEnum.A, table.select<TestEnum>(property("single")).first())
+		assertEquals(TestEnum.A, table.selectValue(property(EnumDao::single)).first())
 	}
 }

--- a/sqlite/src/test/kotlin/tests/sqlite/specific/Json.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/specific/Json.kt
@@ -35,6 +35,6 @@ class JsonTest {
 
 	@Test
 	fun selectSingle() {
-		assertEquals(linkedMapOf("a" to "b", "b" to "a"), table.select<LinkedHashMap<String, String>>(property("map1")).first())
+		assertEquals(linkedMapOf("a" to "b", "b" to "a"), table.selectValue(property(JsonDao::map1)).first())
 	}
 }

--- a/sqlite/src/test/kotlin/tests/sqlite/specific/Locale.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/specific/Locale.kt
@@ -27,6 +27,6 @@ class LocaleTest {
 
 	@Test
 	fun selectAll() {
-		assertEquals(Locale.GERMAN, table.select<Locale>(property("locale")).first())
+		assertEquals(Locale.GERMAN, table.selectValue(property(LocaleDao::locale)).first())
 	}
 }

--- a/sqlite/src/test/kotlin/tests/sqlite/specific/Null.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/specific/Null.kt
@@ -29,7 +29,7 @@ class NullTest {
 
 	@Test
 	fun selectAll() {
-		val result = table.select<String?>(property("test")).list()
+		val result = table.selectValue(property(NullDao::test)).list()
 
 		assertEquals(2, result.size)
 
@@ -39,8 +39,8 @@ class NullTest {
 
 	@Test
 	fun selectIsNull() {
-		assertEquals("not-null", table.select<String>(property("name"), where = property("test").isNotNull()).first())
-		assertEquals("null", table.select<String>(property("name"), where = property("test").isNull()).first())
+		assertEquals("not-null", table.selectValue(property(NullDao::name), where = property(NullDao::test).isNotNull()).first())
+		assertEquals("null", table.selectValue(property(NullDao::name), where = property(NullDao::test).isNull()).first())
 	}
 
 	@Test
@@ -50,17 +50,17 @@ class NullTest {
 			assertTrue(result.notNullViolation)
 		}
 
-		checkResult(table.update("name", value<String?>(null), where = property("id") isEqualTo value(1)))
-		checkResult(table.update("name", nullValue(), where = property("id") isEqualTo value(1)))
+		checkResult(table.update(NullDao::name, value<String?>(null), where = property(NullDao::id) isEqualTo value(1)))
+		checkResult(table.update(NullDao::name, nullValue(), where = property(NullDao::id) isEqualTo value(1)))
 	}
 
 	@Test
 	fun updateNull() {
-		val result = table.update("test", nullValue(), where = property("id") isEqualTo value(1))
+		val result = table.update(NullDao::test, nullValue(), where = property(NullDao::id) isEqualTo value(1))
 
 		assertTrue(result.isSuccess())
 		assertEquals(1, result.value)
 
-		assertEquals(null, table.select<String?>(property("test"), where = property("id") isEqualTo value(1)).first())
+		assertEquals(null, table.selectValue(property(NullDao::test), where = property(NullDao::id) isEqualTo value(1)).first())
 	}
 }

--- a/sqlite/src/test/kotlin/tests/sqlite/table/CustomTable.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/table/CustomTable.kt
@@ -15,9 +15,9 @@ import kotlin.test.assertTrue
 
 interface UserTable : Table<UserDao> {
     fun createUser(name: String, email: String, age: Int): UserDao = insert(UserDao(name = name, email = email, age = age)).getOrThrow()
-    fun getUserByEmail(email: String): UserDao? = select(where = property("email") isEqualTo value(email)).findFirst()
+    fun getUserByEmail(email: String): UserDao? = select(where = property(UserDao::email) isEqualTo value(email)).findFirst()
 
-    fun updateName(email: String, name: String) = (update("name", value(name), where = property("email") isEqualTo value(email)).value ?: 0) > 0
+    fun updateName(email: String, name: String) = (update(UserDao::name, value(name), where = property(UserDao::email) isEqualTo value(email)).value ?: 0) > 0
 }
 
 class CustomTableTest {

--- a/sqlite/src/test/kotlin/tests/sqlite/table/DataObject.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/table/DataObject.kt
@@ -49,14 +49,14 @@ class DataObjectTest {
 		val result = table.select().list()
 
 		assertEquals(2, result.size)
-		assertEquals(2, result[0].selectReferring(referenceTable, "reference").list().size)
-		assertEquals(3, result[1].selectReferring(referenceTable, "reference").list().size)
+		assertEquals(2, result[0].selectReferring(referenceTable, DataObjectReferenceDao::reference).list().size)
+		assertEquals(3, result[1].selectReferring(referenceTable, DataObjectReferenceDao::reference).list().size)
 	}
 
 	@Test
 	fun update() {
 		assertTrue(referenceTable.update(references[1].copy(reference = 1)).isSuccess())
 
-		assertEquals(3, table.select(where = property("name") isEqualTo value("A")).first().selectReferring(referenceTable, "reference").list().size)
+		assertEquals(3, table.select(where = property(DataObjectDao::name) isEqualTo value("A")).first().selectReferring(referenceTable, DataObjectReferenceDao::reference).list().size)
 	}
 }


### PR DESCRIPTION
The main change of this PR is to allow `property(DaoClass::property)` instead of `property("name")` (This string version is still allowed and also required for complex expressions like virtual column access). This also required some changes to the table interface and adding a type parameter to the Node interface.