### PR TITLE
Add createDummy()

### DIFF
--- a/core/src/main/kotlin/de/mineking/database/DatabaseConnection.kt
+++ b/core/src/main/kotlin/de/mineking/database/DatabaseConnection.kt
@@ -17,6 +17,8 @@ internal val CURRENT_TRANSACTION: ThreadLocal<Handle> = ThreadLocal()
 inline fun <reified T: Annotation> KProperty<*>.getDatabaseAnnotation(): T? = this.javaField?.getAnnotation(T::class.java)
 inline fun <reified T: Annotation> KProperty<*>.hasDatabaseAnnotation(): Boolean = getDatabaseAnnotation<T>() != null
 
+inline fun <reified T> createDummy() = Proxy.newProxyInstance(DatabaseConnection::class.java.classLoader, arrayOf(T::class.java)) { _, _, _ -> }
+
 abstract class DatabaseConnection(
     @Suppress("UNUSED") val driver: Jdbi,
     val defaultNamingStrategy: NamingStrategy


### PR DESCRIPTION
This is useful when having non-nullable types to pass a dummy object in the instance creator