### PR TITLE
Add more flexible annotation handling

### DIFF
--- a/core/src/main/kotlin/de/mineking/database/AnnotationHandler.kt
+++ b/core/src/main/kotlin/de/mineking/database/AnnotationHandler.kt
@@ -1,0 +1,103 @@
+package de.mineking.database
+
+import java.lang.reflect.Method
+import kotlin.reflect.KType
+import kotlin.reflect.jvm.jvmErasure
+import kotlin.reflect.typeOf
+
+val ANNOTATION_EXECUTOR = ThreadLocal<(type: KType) -> Any?>()
+
+@Suppress("UNCHECKED_CAST")
+fun <T> execute(type: KType): T = ANNOTATION_EXECUTOR.get()(type) as T
+inline fun <reified T> execute(): T = execute(typeOf<T>())
+
+interface AnnotationHandler {
+    fun accepts(table: TableImplementation<*>, method: Method, args: Array<out Any?>): Boolean
+    fun execute(table: TableImplementation<*>, type: KType, method: Method, args: Array<out Any?>): Any?
+}
+
+inline fun <reified A: Annotation> annotationHandler(
+    crossinline execute: TableImplementation<*>.(type: KType, method: Method, args: Array<out Any?>, annotation: A) -> Any?
+): AnnotationHandler = object : AnnotationHandler {
+    override fun accepts(table: TableImplementation<*>, method: Method, args: Array<out Any?>) = method.isAnnotationPresent(A::class.java)
+    override fun execute(table: TableImplementation<*>, type: KType, method: Method, args: Array<out Any?>) = execute(table, type, method, args, method.getAnnotation(A::class.java)!!)
+}
+
+object DefaultAnnotationHandlers {
+    fun createCondition(method: Method, args: Array<out Any?>) = allOf(method.parameters
+        .mapIndexed { index, value -> index to value }
+        .filter { (_, it) -> it.isAnnotationPresent(Condition::class.java) }
+        .map { (index, param) -> property<Any>(param.getAnnotation(Condition::class.java)!!.name.takeIf { it.isNotBlank() } ?: param.name) + " ${ param.getAnnotation(Condition::class.java)!!.operation } " + value(args[index]) }
+        .map { Where(it) }
+    )
+
+    fun <T: Any> createObject(table: TableImplementation<T>, method: Method, args: Array<out Any?>): T {
+        val obj = table.instance()
+
+        method.parameters
+            .mapIndexed { index, value -> index to value }
+            .filter { (_, it) -> it.isAnnotationPresent(Parameter::class.java) }
+            .forEach { (index, param) ->
+                val name = param.getAnnotation(Parameter::class.java)!!.name.takeIf { it.isNotBlank() } ?: param.name
+
+                @Suppress("UNCHECKED_CAST")
+                val column = table.structure.getColumnFromCode(name) as DirectColumnData<Any, Any>? ?: error("Column $name not found")
+                val value = args[index]
+
+                column.set(obj, value)
+            }
+
+        return obj
+    }
+
+    val SELECT = annotationHandler<Select> { type, function, args, _ ->
+        val value = select(where = createCondition(function, args))
+        when {
+            type.jvmErasure.java == QueryResult::class.java -> value
+            type.jvmErasure.java == List::class.java -> value.list()
+            type.isMarkedNullable -> value.findFirst()
+            else -> value.first()
+        }
+    }
+
+    val INSERT = annotationHandler<Insert> { type, function, args, _ ->
+        fun <T: Any> execute(table: TableImplementation<T>) = table.insert(createObject(table, function, args))
+        val value = execute(this)
+
+        when {
+            type.jvmErasure.java == UpdateResult::class.java -> value
+            else -> value.getOrThrow()
+        }
+    }
+
+    val UPSERT = annotationHandler<Insert> { type, function, args, _ ->
+        fun <T: Any> execute(table: TableImplementation<T>) = table.upsert(createObject(table, function, args))
+        val value = execute(this)
+
+        when {
+            type.jvmErasure.java == UpdateResult::class.java -> value
+            else -> value.getOrThrow()
+        }
+    }
+
+    val UPDATE = annotationHandler<Update> { type, function, args, _ ->
+        val updates = function.parameters
+            .mapIndexed { index, value -> index to value }
+            .filter { (_, it) -> it.isAnnotationPresent(Parameter::class.java) }
+            .map { (index, param) -> property<Any>(param.getAnnotation(Parameter::class.java)!!.name.takeIf { it.isNotBlank() } ?: param.name) to value(args[index]) }
+
+        val value = update(columns = updates.toTypedArray(), where = createCondition(function, args))
+        when {
+            type.jvmErasure.java == UpdateResult::class.java -> value
+            else -> value.getOrThrow()
+        }
+    }
+
+    val DELETE = annotationHandler<Delete> { type, function, args, _ ->
+        val value = delete(where = createCondition(function, args))
+        when {
+            type.jvmErasure.java == Boolean::class.java -> value > 0
+            else -> value
+        }
+    }
+}

--- a/core/src/main/kotlin/de/mineking/database/DatabaseConnection.kt
+++ b/core/src/main/kotlin/de/mineking/database/DatabaseConnection.kt
@@ -25,6 +25,7 @@ abstract class DatabaseConnection(
 ) {
     val data: MutableMap<String, Any> = mutableMapOf()
     val typeMappers: MutableList<TypeMapper<*, *>> = arrayListOf()
+    val annotationHandlers: MutableList<AnnotationHandler> = DefaultAnnotationHandlers::class.memberProperties.map { it.get(DefaultAnnotationHandlers) as AnnotationHandler }.toMutableList()
 
     var autoGenerate: (ColumnData<*, *>) -> String = { error("No default autogenerate configured") }
 

--- a/core/src/main/kotlin/de/mineking/database/DatabaseConnection.kt
+++ b/core/src/main/kotlin/de/mineking/database/DatabaseConnection.kt
@@ -45,7 +45,7 @@ abstract class DatabaseConnection(
         namingStrategy: NamingStrategy = defaultNamingStrategy
     ): TableStructure<T> {
         val columns = arrayListOf<DirectColumnData<T, *>>()
-        val table = TableStructure(this, name, namingStrategy, columns)
+        val table = TableStructure(this, name, namingStrategy, type, columns)
 
         fun <C> createColumn(property: KProperty1<T, C>): DirectColumnData<T, C> {
             val nameOverride = property.getDatabaseAnnotation<Column>()?.name?.takeIf { it.isNotBlank() }

--- a/core/src/main/kotlin/de/mineking/database/Table.kt
+++ b/core/src/main/kotlin/de/mineking/database/Table.kt
@@ -288,84 +288,35 @@ abstract class TableImplementation<T: Any>(
 
 	override fun invoke(proxy: Any?, method: Method?, args: Array<out Any?>?): Any? {
 		require(method != null)
+		val args = args ?: emptyArray()
 
-		fun createCondition() = allOf(if (args == null) emptyList() else method.parameters
-			.mapIndexed { index, value -> index to value }
-			.filter { (_, it) -> it.isAnnotationPresent(Condition::class.java) }
-			.map { (index, param) -> property<Any>(param.getAnnotation(Condition::class.java)!!.name.takeIf { it.isNotBlank() } ?: param.name) + " ${ param.getAnnotation(Condition::class.java)!!.operation } " + value(args[index]) }
-			.map { Where(it) }
-		)
-
-		when {
-			method.isAnnotationPresent(Select::class.java) -> {
-				val result = select(where = createCondition())
-
-				return when {
-					method.returnType == QueryResult::class.java -> result
-					method.returnType == List::class.java -> result.list()
-					method.kotlinFunction?.returnType?.isMarkedNullable == true -> result.findFirst()
-					else -> result.first()
-				}
-			}
-
-			method.isAnnotationPresent(Insert::class.java) || method.isAnnotationPresent(Upsert::class.java) -> {
-				require(args != null)
-
-				val obj = instance()
-
-				method.parameters
-					.mapIndexed { index, value -> index to value }
-					.filter { (_, it) -> it.isAnnotationPresent(Parameter::class.java) }
-					.forEach { (index, param) ->
-						val name = param.getAnnotation(Parameter::class.java)!!.name.takeIf { it.isNotBlank() } ?: param.name
-
-						@Suppress("UNCHECKED_CAST")
-						val column = structure.getColumnFromCode(name) as DirectColumnData<T, Any>? ?: error("Column $name not found")
-						val value = args[index]
-
-						column.set(obj, value)
-					}
-
-				val result = if (method.isAnnotationPresent(Insert::class.java)) insert(obj) else upsert(obj)
-				return when {
-					method.returnType == UpdateResult::class.java -> result
-					else -> result.getOrThrow()
-				}
-			}
-
-			method.isAnnotationPresent(Update::class.java) -> {
-				require(args != null)
-
-				val updates = method.parameters
-					.mapIndexed { index, value -> index to value }
-					.filter { (_, it) -> it.isAnnotationPresent(Parameter::class.java) }
-					.map { (index, param) -> property<Any>(param.getAnnotation(Parameter::class.java)!!.name.takeIf { it.isNotBlank() } ?: param.name) to value(args[index]) }
-
-				val result = update(columns = updates.toTypedArray(), where = createCondition())
-				return when {
-					method.returnType == UpdateResult::class.java -> result
-					else -> result.getOrThrow()
-				}
-			}
-
-			method.isAnnotationPresent(Delete::class.java) -> {
-				val result = delete(where = createCondition())
-				return when {
-					method.returnType == Boolean::class.java -> result > 0
-					else -> result
-				}
-			}
+		val annotationHandler = structure.manager.annotationHandlers.find { it.accepts(this, method, args) }
+		if (annotationHandler != null) {
+			ANNOTATION_EXECUTOR.set { annotationHandler.execute(this, it, method, args) }
+			return invokeDefault(type, method, proxy, args) { execute(method.kotlinFunction!!.returnType) }
 		}
 
 		return try {
-			javaClass.getMethod(method.name, *method.parameterTypes).invoke(this, *(args ?: emptyArray()))
+			javaClass.getMethod(method.name, *method.parameterTypes).invoke(this, *args)
 		} catch(_: NoSuchMethodException) {
-			type.java.classes.find { it.simpleName == "DefaultImpls" }?.getMethod(method.name, type.java, *method.parameterTypes)?.invoke(null, proxy, *(args ?: emptyArray()))
+			invokeDefault(type, method, proxy, args) { throw RuntimeException(it) }
 		} catch(e: IllegalAccessException) {
 			throw RuntimeException(e)
 		} catch(e: InvocationTargetException) {
 			throw e.cause!!
 		}
+	}
+}
+
+private fun invokeDefault(type: KClass<*>, method: Method, instance: Any?, args: Array<out Any?>, default: (e: NoSuchMethodException) -> Any?): Any? {
+	return try {
+		type.java.classes.find { it.simpleName == "DefaultImpls" }?.getMethod(method.name, type.java, *method.parameterTypes)?.invoke(null, instance, *args)
+	} catch (e: IllegalAccessException) {
+		throw RuntimeException(e)
+	} catch (e: NoSuchMethodException) {
+		default(e)
+	} catch (e: InvocationTargetException) {
+		throw e.cause!!
 	}
 }
 

--- a/core/src/main/kotlin/de/mineking/database/Table.kt
+++ b/core/src/main/kotlin/de/mineking/database/Table.kt
@@ -379,6 +379,7 @@ data class TableStructure<T: Any>(
 	val manager: DatabaseConnection,
 	val name: String,
 	val namingStrategy: NamingStrategy,
+	val type: KClass<T>,
 	val columns: List<DirectColumnData<T, *>>
 ) {
 	fun getColumnFromDatabase(name: String): ColumnData<T, *>? = getAllColumns().find { it.name == name }

--- a/postgres/src/test/kotlin/tests/postgres/table/AnnotationTable.kt
+++ b/postgres/src/test/kotlin/tests/postgres/table/AnnotationTable.kt
@@ -27,6 +27,9 @@ interface AnnotationTable : Table<UserDao> {
 
     @Update
     fun update(@Condition id: Int, @Parameter name: String): Int
+
+    @Select
+    fun modifiedSelect(): Set<UserDao> = execute<List<UserDao>>().toSet()
 }
 
 class AnnotationTableTest {
@@ -74,5 +77,10 @@ class AnnotationTableTest {
         assertEquals(1, table.update(1, "Test"))
 
         assertEquals("Test", table.getUserByEmail("tom@example.com")?.name)
+    }
+
+    @Test
+    fun modifiedSelect() {
+        assertEquals(table.getAllUsers().toSet(), table.modifiedSelect())
     }
 }

--- a/sqlite/src/test/kotlin/tests/sqlite/table/AnnotationTable.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/table/AnnotationTable.kt
@@ -27,6 +27,9 @@ interface AnnotationTable : Table<UserDao> {
 
     @Update
     fun update(@Condition id: Int, @Parameter name: String): Int
+
+    @Select
+    fun modifiedSelect(): Set<UserDao> = execute<List<UserDao>>().toSet()
 }
 
 class AnnotationTableTest {
@@ -74,5 +77,10 @@ class AnnotationTableTest {
         assertEquals(1, table.update(1, "Test"))
 
         assertEquals("Test", table.getUserByEmail("tom@example.com")?.name)
+    }
+
+    @Test
+    fun modifiedSelect() {
+        assertEquals(table.getAllUsers().toSet(), table.modifiedSelect())
     }
 }


### PR DESCRIPTION
Moves restricted implementations for custom table method annotations from TableImplementation to a dedicated AnnotationHandler interface. All previously supported annotations have been migrated to the new system. Therefore this does not change any current behavior. However, it allows users to add custom annotations.

This also allows functions that are handles by an AnnotationHandler to have a default implementation. In that case, the default method body is executed and the default action can executed with the execute<T>() function.

Example:
```kotlin
data class Test(
  @Column val a: String,
  @Column val b: String
)

interface TestTable : Table<Test> {
  @Select
  fun test(): Set<Test> = execute<List<Test>>().toSet()
}
```

The example above shows how the possibility to add a method body allows to return other types than allowed by default by simply transforming the result of the execute function (by default the select annotation only allows List<T>, T, T? and QueryResult return types). 
However, you can also have more complex method bodies that have arbitrary code before and after the execute() call. 