### PR TITLE
Add limit and offset annotations

### DIFF
--- a/core/src/main/kotlin/de/mineking/database/AnnotationHandler.kt
+++ b/core/src/main/kotlin/de/mineking/database/AnnotationHandler.kt
@@ -1,14 +1,9 @@
 package de.mineking.database
 
-import com.sun.tools.javac.tree.TreeInfo.args
 import java.lang.reflect.Method
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
-import kotlin.reflect.full.createType
-import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.hasAnnotation
-import kotlin.reflect.full.isSubtypeOf
-import kotlin.reflect.full.valueParameters
+import kotlin.reflect.full.*
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.jvm.kotlinFunction
 import kotlin.reflect.typeOf

--- a/core/src/main/kotlin/de/mineking/database/Annotations.kt
+++ b/core/src/main/kotlin/de/mineking/database/Annotations.kt
@@ -40,6 +40,15 @@ annotation class Parameter(val name: String = "")
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Condition(val name: String = "", val operation: String = " = ")
 
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Limit
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Offset
+
+
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Select

--- a/core/src/main/kotlin/de/mineking/database/DatabaseConnection.kt
+++ b/core/src/main/kotlin/de/mineking/database/DatabaseConnection.kt
@@ -1,6 +1,5 @@
 package de.mineking.database
 
-import jdk.internal.org.jline.utils.InfoCmp.Capability.columns
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.inTransactionUnchecked

--- a/core/src/main/kotlin/de/mineking/database/Nodes.kt
+++ b/core/src/main/kotlin/de/mineking/database/Nodes.kt
@@ -1,7 +1,6 @@
 package de.mineking.database
 
 import org.jdbi.v3.core.argument.Argument
-import org.jdbi.v3.core.kotlin.isKotlinClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType

--- a/postgres/src/test/kotlin/tests/postgres/table/AnnotationTable.kt
+++ b/postgres/src/test/kotlin/tests/postgres/table/AnnotationTable.kt
@@ -17,6 +17,8 @@ interface AnnotationTable : IdentifiableTable<UserDao> {
     @Select fun getUserByEmail(@Condition email: String): UserDao?
     @Select fun modifiedSelect(): Set<UserDao> = execute<List<UserDao>>().toSet()
 
+    @SelectValue("name") fun selectFirst(@Limit limit: Int, order: Order): List<String>
+
     @SelectValue("name") fun selectValue(): List<String>
     @SelectValue("name") fun selectSingleValue(@Condition id: Int): String?
 
@@ -69,6 +71,11 @@ class AnnotationTableTest {
 
         assertEquals("Tom", table.selectSingleValue(1))
         assertEquals(null, table.selectSingleValue(0))
+    }
+
+    @Test
+    fun selectFirst() {
+        assertEquals(listOf("Tom", "Max"), table.selectFirst(2, order = ascendingBy(UserDao::age)))
     }
 
     @Test

--- a/sqlite/src/test/kotlin/tests/sqlite/table/AnnotationTable.kt
+++ b/sqlite/src/test/kotlin/tests/sqlite/table/AnnotationTable.kt
@@ -17,6 +17,8 @@ interface AnnotationTable : IdentifiableTable<UserDao> {
     @Select fun getUserByEmail(@Condition email: String): UserDao?
     @Select fun modifiedSelect(): Set<UserDao> = execute<List<UserDao>>().toSet()
 
+    @SelectValue("name") fun selectFirst(@Limit limit: Int, order: Order): List<String>
+
     @SelectValue("name") fun selectValue(): List<String>
     @SelectValue("name") fun selectSingleValue(@Condition id: Int): String?
 
@@ -74,6 +76,11 @@ class AnnotationTableTest {
 
         assertEquals("Tom", table.selectSingleValue(1))
         assertEquals(null, table.selectSingleValue(0))
+    }
+
+    @Test
+    fun selectFirst() {
+        assertEquals(listOf("Tom", "Max"), table.selectFirst(2, order = ascendingBy(UserDao::age)))
     }
 
     @Test


### PR DESCRIPTION
Add @Limit and @Offset to allow @Select and @SelectValue functions to set those properties. This also makes the handlers for select and select value automatically handle parameters of type `Order` and `Where` accordingly. These do not require an annotation.